### PR TITLE
Add support for nested array to grouped list conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,21 @@ Same as ```format(fmt, ...)``` except parameters are provided in an array rather
 Node buffers can be used for literals (```%L```) and strings (```%s```), and will be converted to [PostgreSQL bytea hex format](http://www.postgresql.org/docs/9.3/static/datatype-binary.html).
 
 ## <a name="arrobject"></a> Arrays and Objects
-For arrays, each element is escaped when appropriate and concatenated to a comma-delimited string. For objects, ```JSON.stringify()``` is called and the resulting string is escaped if appropriate. Objects can be used for literals (```%L```) and strings (```%s```), but not identifiers (```%I```). See the example below.
+For arrays, each element is escaped when appropriate and concatenated to a comma-delimited string. Nested arrays are turned into grouped lists (for bulk inserts), e.g. [['a', 'b'], ['c', 'd']] turns into ('a', 'b'), ('c', 'd'). Nested array expansion can be used for literals (```%L```) and strings (```%s```), but not identifiers (```%I```).  
+For objects, ```JSON.stringify()``` is called and the resulting string is escaped if appropriate. Objects can be used for literals (```%L```) and strings (```%s```), but not identifiers (```%I```). See the example below.
 
 ```js
 var format = require('pg-format');
 
 var myArray = [ 1, 2, 3 ];
 var myObject = { a: 1, b: 2 };
+var myNestedArray = [['a', 1], ['b', 2]];
 
 var sql = format('SELECT * FROM t WHERE c1 IN (%L) AND c2 = %L', myArray, myObject);
 console.log(sql); // SELECT * FROM t WHERE c1 IN ('1','2','3') AND c2 = '{"a":1,"b":2}'
+
+sql = format('INSERT INTO t (name, age) VALUES %L', myNestedArray); 
+console.log(sql); // INSERT INTO t (name, age) VALUES ('a', '1'), ('b', '2')
 ```
 
 ## Testing

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // reserved Postgres words
 var reservedMap = require(__dirname + '/reserved.js');
 
@@ -19,6 +21,19 @@ function isReserved(value) {
         return true;
     }
     return false;
+}
+
+function arrayToList(useSpace, array, formatter) {
+    var sql = '';
+    var temp = [];
+
+    sql += useSpace ? ' (' : '(';
+    array.forEach(function(value, i) {
+      sql += (i === 0 ? '' : ', ') + formatter(value);
+    });
+    sql += ')';
+
+    return sql;
 }
 
 // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
@@ -85,7 +100,11 @@ function quoteLiteral(value) {
     } else if (Array.isArray(value) === true) {
         var temp = [];
         for (var i = 0; i < value.length; i++) {
-            temp.push(quoteLiteral(value[i]));
+            if (Array.isArray(value[i])) {
+                temp.push(arrayToList(i !== 0, value[i], quoteLiteral))
+            } else {
+                temp.push(quoteLiteral(value[i]));
+            }
         }
         return temp.toString();
     } else if (value === Object(value)) {
@@ -134,7 +153,11 @@ function quoteString(value) {
         var temp = [];
         for (var i = 0; i < value.length; i++) {
             if (value[i] !== null && value[i] !== undefined) {
-                temp.push(quoteString(value[i]));
+                if (Array.isArray(value[i])) {
+                    temp.push(arrayToList(i !== 0, value[i], quoteString));
+                } else {
+                    temp.push(quoteString(value[i]));
+                }
             }
         }
         return temp.toString();

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,9 +28,9 @@ function arrayToList(useSpace, array, formatter) {
     var temp = [];
 
     sql += useSpace ? ' (' : '(';
-    array.forEach(function(value, i) {
-      sql += (i === 0 ? '' : ', ') + formatter(value);
-    });
+    for (var i = 0; i < array.length; i++) {
+      sql += (i === 0 ? '' : ', ') + formatter(array[i]);
+    }
     sql += ')';
 
     return sql;
@@ -52,7 +52,11 @@ function quoteIdent(value) {
     } else if (Array.isArray(value) === true) {
         var temp = [];
         for (var i = 0; i < value.length; i++) {
-            temp.push(quoteIdent(value[i]));
+            if (Array.isArray(value[i]) === true) {
+                throw new Error('Nested array to grouped list conversion is not supported for SQL identifier');
+            } else {
+                temp.push(quoteIdent(value[i]));
+            }
         }
         return temp.toString();
     } else if (value === Object(value)) {
@@ -100,7 +104,7 @@ function quoteLiteral(value) {
     } else if (Array.isArray(value) === true) {
         var temp = [];
         for (var i = 0; i < value.length; i++) {
-            if (Array.isArray(value[i])) {
+            if (Array.isArray(value[i]) === true) {
                 temp.push(arrayToList(i !== 0, value[i], quoteLiteral))
             } else {
                 temp.push(quoteLiteral(value[i]));
@@ -153,7 +157,7 @@ function quoteString(value) {
         var temp = [];
         for (var i = 0; i < value.length; i++) {
             if (value[i] !== null && value[i] !== undefined) {
-                if (Array.isArray(value[i])) {
+                if (Array.isArray(value[i]) === true) {
                     temp.push(arrayToList(i !== 0, value[i], quoteString));
                 } else {
                     temp.push(quoteString(value[i]));

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "dependencies": {
     },
     "devDependencies": {
+        "istanbul": "^0.4.2",
         "mocha": "2.4.5",
         "should": "8.2.1"
     },
     "scripts": {
-        "test": "node ./node_modules/mocha/bin/mocha"
+        "test": "node ./node_modules/mocha/bin/mocha",
+        "cover-test": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha"
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "dependencies": {
     },
     "devDependencies": {
-        "mocha": "2.3.3",
-        "should": "7.1.1"
+        "mocha": "2.4.5",
+        "should": "8.2.1"
     },
     "scripts": {
         "test": "node ./node_modules/mocha/bin/mocha"

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,12 @@ describe('format(fmt, ...)', function() {
         it('should format as an identifier', function() {
             format('some %I', 'foo/bar/baz').should.equal('some "foo/bar/baz"');
         });
+
+        it('should not format array of array as an identifier', function() {
+            (function() {
+                format('many %I %I', 'foo/bar/baz', testNestedArray);
+            }).should.throw(Error);
+        });
     });
 
     describe('%L', function() {
@@ -77,6 +83,12 @@ describe('format.withArray(fmt, args)', function() {
         it('should format as an identifier', function() {
             format.withArray('some %I', [ 'foo/bar/baz' ]).should.equal('some "foo/bar/baz"');
             format.withArray('some %I and %I', [ 'foo/bar/baz', '#hey' ]).should.equal('some "foo/bar/baz" and "#hey"');
+        });
+
+        it('should not format array of array as an identifier', function() {
+            (function() {
+                format.withArray('many %I %I', ['foo/bar/baz', testNestedArray]);
+            }).should.throw(Error);
         });
     });
 
@@ -135,6 +147,9 @@ describe('format.ident(val)', function() {
         format.ident(45.13).should.equal('"45.13"');
         format.ident(-45.13).should.equal('"-45.13"');
         format.ident(testIdentArray).should.equal('abc,"AbC","1","t","2012-12-14 13:06:43.152+00"');
+        (function() {
+            format.ident(testNestedArray)
+        }).should.throw(Error);
         format.ident(testDate).should.equal('"2012-12-14 13:06:43.152+00"');
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -9,12 +9,17 @@ var testDate = new Date(Date.UTC(2012, 11, 14, 13, 6, 43, 152));
 var testArray = [ 'abc', 1, true, null, testDate ];
 var testIdentArray = [ 'abc', 'AbC', 1, true, testDate ];
 var testObject = { a: 1, b: 2 };
+var testNestedArray = [ [1, 2], [3, 4], [5, 6] ];
 
 describe('format(fmt, ...)', function() {
     describe('%s', function() {
         it('should format as a simple string', function() {
             format('some %s here', 'thing').should.equal('some thing here');
             format('some %s thing %s', 'long', 'here').should.equal('some long thing here');
+        });
+
+        it('should format array of array as simple string', function() {
+            format('many %s %s', 'things', testNestedArray).should.equal('many things (1, 2), (3, 4), (5, 6)');
         });
     });
 
@@ -38,6 +43,10 @@ describe('format(fmt, ...)', function() {
         it('should format as a literal', function() {
             format('%L', "Tobi's").should.equal("'Tobi''s'");
         });
+
+        it('should format array of array as a literal', function() {
+            format('%L', testNestedArray).should.equal("('1', '2'), ('3', '4'), ('5', '6')");
+        });
     });
 });
 
@@ -46,6 +55,10 @@ describe('format.withArray(fmt, args)', function() {
         it('should format as a simple string', function() {
             format.withArray('some %s here', [ 'thing' ]).should.equal('some thing here');
             format.withArray('some %s thing %s', [ 'long', 'here' ]).should.equal('some long thing here');
+        });
+
+        it('should format array of array as simple string', function() {
+            format.withArray('many %s %s', ['things', testNestedArray]).should.equal('many things (1, 2), (3, 4), (5, 6)');
         });
     });
 
@@ -72,6 +85,10 @@ describe('format.withArray(fmt, args)', function() {
             format.withArray('%L', [ "Tobi's" ]).should.equal("'Tobi''s'");
             format.withArray('%L %L', [ "Tobi's", "birthday" ]).should.equal("'Tobi''s' 'birthday'");
         });
+
+        it('should format array of array as a literal', function() {
+            format.withArray('%L', [testNestedArray]).should.equal("('1', '2'), ('3', '4'), ('5', '6')");
+        });
     });
 });
 
@@ -88,6 +105,7 @@ describe('format.string(val)', function() {
         format.string(-45.13).should.equal('-45.13');
         format.string('something').should.equal('something');
         format.string(testArray).should.equal('abc,1,t,2012-12-14 13:06:43.152+00');
+        format.string(testNestedArray).should.equal('(1, 2), (3, 4), (5, 6)');
         format.string(testDate).should.equal('2012-12-14 13:06:43.152+00');
         format.string(testObject).should.equal('{"a":1,"b":2}');
     });
@@ -164,6 +182,7 @@ describe('format.literal(val)', function() {
         format.literal(-45.13).should.equal("'-45.13'");
         format.literal('hello world').should.equal("'hello world'");
         format.literal(testArray).should.equal("'abc','1','t',NULL,'2012-12-14 13:06:43.152+00'");
+        format.literal(testNestedArray).should.equal("('1', '2'), ('3', '4'), ('5', '6')");
         format.literal(testDate).should.equal("'2012-12-14 13:06:43.152+00'");
         format.literal(testObject).should.equal("'{\"a\":1,\"b\":2}'");
     });


### PR DESCRIPTION
This ports the the handly feature of the node MySQL client where nested arrays are
grouped into lists, i.e. [[1, 2], [3,4]] => (1, 2), (3, 4) for easy bulk insert syntax generation.
See https://github.com/felixge/node-mysql#escaping-query-values for details.

Note the conversion currently applies to string and literals escaping only as the others don't really make sense
