### PR TITLE
require file in a way more friendly to static-analysis.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // reserved Postgres words
-var reservedMap = require(__dirname + '/reserved.js');
+var reservedMap = require('./reserved.js');
 
 var fmtPattern = {
     ident: 'I',


### PR DESCRIPTION
Specifically, require(__dirname + '/reserved.js') confuses pkg. If this is unacceptable, path.join(__dirname, 'reserved.js') should be understandable by pkg and in any case would be more portable.