### PR TITLE
Update SQL reserved Key Words list for Postgres 13

### DIFF
--- a/lib/reserved.js
+++ b/lib/reserved.js
@@ -1,5 +1,6 @@
 //
 // PostgreSQL reserved words
+// see: https://www.postgresql.org/docs/current/sql-keywords-appendix.html
 //
 module.exports = {
     "AES128": true,
@@ -13,6 +14,7 @@ module.exports = {
     "ARRAY": true,
     "AS": true,
     "ASC": true,
+    "ASYMMETRIC": true,
     "AUTHORIZATION": true,
     "BACKUP": true,
     "BETWEEN": true,
@@ -29,7 +31,9 @@ module.exports = {
     "CREATE": true,
     "CREDENTIALS": true,
     "CROSS": true,
+    "CURRENT_CATALOG": true,
     "CURRENT_DATE": true,
+    "CURRENT_ROLE": true,
     "CURRENT_TIME": true,
     "CURRENT_TIMESTAMP": true,
     "CURRENT_USER": true,
@@ -54,6 +58,7 @@ module.exports = {
     "EXCEPT": true,
     "EXPLICIT": true,
     "FALSE": true,
+    "FETCH": true,
     "FOR": true,
     "FOREIGN": true,
     "FREEZE": true,
@@ -76,6 +81,7 @@ module.exports = {
     "IS": true,
     "ISNULL": true,
     "JOIN": true,
+    "LATERAL": true,
     "LEADING": true,
     "LEFT": true,
     "LIKE": true,
@@ -119,11 +125,13 @@ module.exports = {
     "REJECTLOG": true,
     "RESORT": true,
     "RESTORE": true,
+    "RETURNING": true,
     "RIGHT": true,
     "SELECT": true,
     "SESSION_USER": true,
     "SIMILAR": true,
     "SOME": true,
+    "SYMMETRIC": true,
     "SYSDATE": true,
     "SYSTEM": true,
     "TABLE": true,
@@ -141,10 +149,12 @@ module.exports = {
     "UNIQUE": true,
     "USER": true,
     "USING": true,
+    "VARIADIC": true,
     "VERBOSE": true,
     "WALLET": true,
     "WHEN": true,
     "WHERE": true,
+    "WINDOW": true,
     "WITH": true,
     "WITHOUT": true,
 };


### PR DESCRIPTION
Add all key words listed as "reserved" in PostgreSQL v13 docs to the reserved list.

See https://www.postgresql.org/docs/13/sql-keywords-appendix.html

Also adds a link to the docs to make keeping the list up-to-date easier.

Closes #1 