### PR TITLE
Remove dynamic require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // reserved Postgres words
-var reservedMap = require(__dirname + '/reserved.js');
+var reservedMap = require('./reserved');
 
 var fmtPattern = {
     ident: 'I',


### PR DESCRIPTION
As far as I can tell this dynamic require doesn't need to be dynamic. Currently it is causing issues with some bundlers like esbuild, which do not include the reserved.js file in the final bundle due to the dynamic import.

Should fix
https://github.com/datalanche/node-pg-format/issues/28
https://github.com/datalanche/node-pg-format/issues/29